### PR TITLE
Initial Pull Request

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,6 +8,8 @@ enable_list:
   - fcqn-builtins
   - no-log-password
   - no-same-owner
+skip_list:
+  - no-handler
 exclude_paths:
   # This exclusion is implicit, unless exclude_paths is defined
   - .cache

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,8 +8,6 @@ enable_list:
   - fcqn-builtins
   - no-log-password
   - no-same-owner
-skip_list:
-  - no-handler
 exclude_paths:
   # This exclusion is implicit, unless exclude_paths is defined
   - .cache

--- a/README.md
+++ b/README.md
@@ -13,14 +13,9 @@ None.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
-| required_variable | Describe its purpose. | n/a | Yes |
--->
+| installer_version | A git commit hash, tag, or branch specifying the version of the Metasploit Framework installer to use. | `6.2.20` | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ Alexander King - <alexander.king@trio.dhs.gov>
 I would be remiss to not mention [Liam Somerville](https://github.com/leesoh)
 here. This role is largely based on their prior work.
 
-[Metasploit](https://github.com/rapid7/metasploit-framework) is a project of
-[Rapid7](https://www.rapid7.com/) in collaboration with the open source
-community.
+The [Metasploit Framework](https://github.com/rapid7/metasploit-framework) is a
+project of [Rapid7](https://www.rapid7.com/) in collaboration with the open
+source community.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,8 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/cisagov/ansible-role-metasploit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-metasploit/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-metasploit.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-metasploit/context:python)
 
-This is a skeleton project that can be used to quickly get a new
-[cisagov](https://github.com/cisagov) Ansible role GitHub project
-started.  This skeleton project contains
-[licensing information](LICENSE), as well as
-[pre-commit hooks](https://pre-commit.com) and
-[GitHub Actions](https://github.com/features/actions) configurations
-appropriate for an Ansible role.
+This Ansible role downloads and installs the
+[Metasploit penetration testing framework](https://www.metasploit.com).
 
 ## Requirements ##
 
@@ -40,15 +35,8 @@ Here's how to use it in a playbook:
   become: yes
   become_method: sudo
   roles:
-    - skeleton
+    - metasploit
 ```
-
-## New Repositories from a Skeleton ##
-
-Please see our [Project Setup guide](https://github.com/cisagov/development-guide/tree/develop/project_setup)
-for step-by-step instructions on how to start a new repository from
-a skeleton. This will save you time and effort when configuring a
-new repository!
 
 ## Contributing ##
 
@@ -70,4 +58,11 @@ with this waiver of copyright interest.
 
 ## Author Information ##
 
-First Last - <first.last@trio.dhs.gov>
+Alexander King - <alexander.king@trio.dhs.gov>
+
+I would be remiss to not mention [Liam Somerville](https://github.com/leesoh)
+here. This role is largely based on their prior work.
+
+[Metasploit](https://github.com/rapid7/metasploit-framework) is a project of
+[Rapid7](https://www.rapid7.com/) in collaboration with the open source
+community.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # A commit hash, tag, or branch name indicating what version of the
 # Metasploit Framework installer to use.
-installer_version: 6.2.20
+installer_version: "6.2.20"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # A commit hash, tag, or branch name indicating what version of the
-# Metasploit Framework installer to use
+# Metasploit Framework installer to use.
 installer_version: 6.2.20

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# The directory where Metasploit Framework is installed
+install_directory: /opt/metasploit-framework

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 # The directory where Metasploit Framework is to be installed
 install_directory: /opt/metasploit-framework
+
+# A commit hash, tag, or branch name indicating what version of the
+# Metasploit Framework installer to use
+installer_version: 6.2.20

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-# The directory where Metasploit Framework is to be installed
-install_directory: /opt/metasploit-framework
-
 # A commit hash, tag, or branch name indicating what version of the
 # Metasploit Framework installer to use
 installer_version: 6.2.20

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-# The directory where Metasploit Framework is installed
+# The directory where Metasploit Framework is to be installed
 install_directory: /opt/metasploit-framework

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,12 @@
 ---
 galaxy_info:
-  author: First Last
-  description: Skeleton Ansible role
+  author: Alexander King
+  description: Ansible role that downloads and installs the Metasploit Framework.
   company: CISA Cyber Assessments
   galaxy_tags:
-    - skeleton
+    - metasploit
+    - pentest
+    - security
   license: CC0
   # With the release of version 2.10, Ansible finally correctly
   # identifies Kali Linux as being the Kali distribution of the Debian
@@ -34,6 +36,6 @@ galaxy_info:
       versions:
         - bionic
         - focal
-  role_name: skeleton
+  role_name: metasploit
 
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Alexander King
-  description: Ansible role that downloads and installs the Metasploit Framework.
+  description: Download and install the Metasploit Framework
   company: CISA Cyber Assessments
   galaxy_tags:
     - metasploit

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,6 +6,7 @@ galaxy_info:
   galaxy_tags:
     - metasploit
     - pentest
+    - rapid7
     - security
   license: CC0
   # With the release of version 2.10, Ansible finally correctly

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,14 +12,14 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_installer_deleted(host):
-    """Test that the Metasploit framework installer was removed."""
+    """Test that the Metasploit Framework installer was removed."""
     path = "/tmp/msfinstall"
     f = host.file(path)
     assert not f.exists
 
 
 def test_msf_installed(host):
-    """Test that the Metasploit framework was installed."""
+    """Test that the Metasploit Framework was installed."""
     dir_full_path = "/opt/metasploit-framework/"
     directory = host.file(dir_full_path)
     assert directory.exists

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,4 +18,4 @@ def test_msf_installed(host):
     assert directory.exists
     assert directory.is_directory
     # Assert directory is non-empty
-    assert host.run_expect([0], f'[ -n "$(ls -A {dir_full_path})" ]')
+    assert host.run_expect([0], f'[ -n "$(ls --almost-all {dir_full_path})" ]')

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -11,8 +11,15 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
+def test_installer_deleted(host):
+    """Test that the Metasploit framework installer was removed."""
+    path = "/tmp/msfinstall"
+    f = host.file(path)
+    assert not f.exists
+
+
 def test_msf_installed(host):
-    """Test that the Metasploit framework installer was installed."""
+    """Test that the Metasploit framework was installed."""
     dir_full_path = "/opt/metasploit-framework/"
     directory = host.file(dir_full_path)
     assert directory.exists

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -4,7 +4,6 @@
 import os
 
 # Third-Party Libraries
-import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -12,7 +11,11 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("x", [True])
-def test_packages(host, x):
-    """Run a dummy test, just to show what one would look like."""
-    assert x
+def test_msf_installed(host):
+    """Test that the Metasploit framework installer was installed."""
+    dir_full_path = "/opt/metasploit-framework/"
+    directory = host.file(dir_full_path)
+    assert directory.exists
+    assert directory.is_directory
+    # Assert directory is non-empty
+    assert host.run_expect([0], f'[ -n "$(ls -A {dir_full_path})" ]')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,8 @@
   block:
     - name: Download the Metasploit Framework installer
       ansible.builtin.get_url:
+        # TODO: https://github.com/cisagov/ansible-role-metasploit/issues/6
+        # Replace this installer script
         url: https://raw.githubusercontent.com/rapid7/metasploit-omnibus/{{ installer_version }}/config/templates/metasploit-framework-wrappers/msfupdate.erb
         dest: /tmp/msfinstall
         mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,24 @@
 ---
-- name: Download Metasploit Framework Installer
-  ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb
-    dest: /tmp/msfinstall
-    mode: 0755
+- name: Check if Metasploit Framework is already installed
+  ansible.builtin.stat:
+    path: "{{ install_directory }}"
+  register: msf_directory
 
 - name: Install Metasploit Framework
-  ansible.builtin.command: /tmp/msfinstall
+  block:
+    - name: Download Metasploit Framework Installer
+      ansible.builtin.get_url:
+        url: https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb
+        dest: /tmp/msfinstall
+        mode: 0755
 
-- name: Delete Metasploit Framework Installer
-  ansible.builtin.file:
-    path: /tmp/msfinstall
-    state: absent
-  become: no
-  delegate_to: localhost
+    - name: Install Metasploit Framework
+      ansible.builtin.command:
+        cmd: /tmp/msfinstall
+        creates: "{{ install_directory }}"
+
+    - name: Delete Metasploit Framework Installer
+      ansible.builtin.file:
+        path: /tmp/msfinstall
+        state: absent
+  when: not msf_directory.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,23 @@
 ---
-- name: Check if Metasploit Framework is already installed
+- name: Check if the Metasploit Framework is already installed
   ansible.builtin.stat:
     path: "{{ install_directory }}"
   register: msf_directory
 
-- name: Install Metasploit Framework
+- name: Install the Metasploit Framework
   block:
-    - name: Download Metasploit Framework Installer
+    - name: Download the Metasploit Framework installer
       ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb
         dest: /tmp/msfinstall
         mode: 0755
 
-    - name: Install Metasploit Framework
+    - name: Install the Metasploit Framework
       ansible.builtin.command:
         cmd: /tmp/msfinstall
         creates: "{{ install_directory }}"
 
-    - name: Delete Metasploit Framework Installer
+    - name: Delete the Metasploit Framework installer
       ansible.builtin.file:
         path: /tmp/msfinstall
         state: absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   block:
     - name: Download the Metasploit Framework installer
       ansible.builtin.get_url:
-        url: https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb
+        url: https://raw.githubusercontent.com/rapid7/metasploit-omnibus/{{ installer_version }}/config/templates/metasploit-framework-wrappers/msfupdate.erb
         dest: /tmp/msfinstall
         mode: 0755
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,11 @@
 ---
 - name: Download Metasploit Framework Installer
-  become: true
   ansible.builtin.get_url:
     url: https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb
     dest: /tmp/msfinstall
     mode: 0755
-  register: metasploit
 
 - name: Install Metasploit Framework
-  when: metasploit.changed
-  become: true
   ansible.builtin.command: /tmp/msfinstall
 
 - name: Delete Metasploit Framework Installer

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,20 @@
 ---
-# tasks file for skeleton
+- name: Download Metasploit Framework Installer
+  become: true
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb
+    dest: /tmp/msfinstall
+    mode: 0755
+  register: metasploit
+
+- name: Install Metasploit Framework
+  when: metasploit.changed
+  become: true
+  ansible.builtin.command: /tmp/msfinstall
+
+- name: Delete Metasploit Framework Installer
+  ansible.builtin.file:
+    path: /tmp/msfinstall
+    state: absent
+  become: no
+  delegate_to: localhost

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# The directory where Metasploit Framework will be installed
+install_directory: /opt/metasploit-framework


### PR DESCRIPTION
## 🗣 Description ##

These first commits modify `skeleton-ansible-role` to download and run the Metasploit framework installer.

## 💭 Motivation and context ##

This pull request was motivated by the discussion under https://github.com/cisagov/kali-packer/issues/112. While already resolved, it would be prudent of us to own our own Ansible role, in case there are any breaking changes in the future. 

- Together with cisagov/kali-packer#119, this PR resolves cisagov/kali-packer#113

## 🧪 Testing ##

I used a virtual environment (`pyenv 2.3.2`) running `python 3.9.7` and updated the default scenario ([84b1c38](https://github.com/cisagov/ansible-role-metasploit/pull/5/commits/84b1c380e51487521f6f74e0dbe77bf5502d887d)) to test my changes. Others can test this pull request with the command `molecule test --scenario-name default`. 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.